### PR TITLE
Restore =head1 NAME section in bin/http_this

### DIFF
--- a/.github/workflows/perltest.yml
+++ b/.github/workflows/perltest.yml
@@ -10,6 +10,10 @@ on:
 jobs:
   test:
     uses: PerlToolsTeam/github_workflows/.github/workflows/cpan-test.yml@main
+    with:
+      # Perl 5.24 is dropped: the Plack::App::DirectoryIndex dependency chain
+      # bottoms out at Perl 5.26 (WebServer::DirIndex needs Feature::Compat::Class).
+      perl_version: "[ '5.26', '5.28', '5.30', '5.32', '5.34', '5.36', '5.38', '5.40', '5.42' ]"
 
   coverage:
     uses: PerlToolsTeam/github_workflows/.github/workflows/cpan-coverage.yml@main

--- a/bin/http_this
+++ b/bin/http_this
@@ -17,6 +17,10 @@ __END__
 
 =encoding utf8
 
+=head1 NAME
+
+http_this - export the current directory over HTTP
+
 =head1 SYNOPSIS
 
     ## Export the current directory with HTTP


### PR DESCRIPTION
## Summary

`bin/http_this` was missing its `=head1 NAME` section, starting directly at `=head1 SYNOPSIS`.

This section was previously auto-generated by Dist::Zilla's `[Pod::Weaver]` plugin from the `# ABSTRACT:` comment. After the dist was converted away from Dist::Zilla, nothing regenerated it.

This restores the section manually, matching the abstract:

```pod
=head1 NAME

http_this - export the current directory over HTTP
```

`lib/App/HTTPThis.pm` already had its `=head1 NAME` section, so only the script needed fixing.

## CI

This PR also drops **Perl 5.24** from the CI matrix. The `Plack::App::DirectoryIndex` dependency chain bottoms out at Perl 5.26 (`WebServer::DirIndex` requires `Feature::Compat::Class`, which needs 5.26), so 5.24 can no longer be supported.

The remaining pre-existing CI failures on Perl 5.26–5.36 are caused by `Plack::App::DirectoryIndex` declaring an unnecessarily high `MIN_PERL_VERSION` of 5.38. That is fixed upstream in **davorg-cpan/plack-app-directoryindex#19**; once that is merged and released to CPAN, this PR's CI will go green for Perl 5.26+.

## Testing

- `podchecker bin/http_this` → pod syntax OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>