### PR TITLE
Be honest about binding to all network interfaces

### DIFF
--- a/bin/http_this
+++ b/bin/http_this
@@ -78,6 +78,13 @@ The following options are available:
 
 Start the HTTP server on a specific C<PORT>.
 
+=item --host HOST
+
+Bind the server to a specific C<HOST> or IP address. By default the server
+binds to all network interfaces, which means other machines on your network
+can reach it. To make the server available only on this computer, use
+C<--host 127.0.0.1> (or C<--host ::1> for IPv6).
+
 =item --name NAME
 
 Announces the server over Bonjour.

--- a/lib/App/HTTPThis.pm
+++ b/lib/App/HTTPThis.pm
@@ -117,12 +117,33 @@ sub run {
 sub _server_ready {
   my ($self, $args) = @_;
 
-  my $host  = $args->{host}  || '127.0.0.1';
+  my $host  = $args->{host};
   my $proto = $args->{proto} || 'http';
   my $port  = $args->{port};
 
+  # An unspecified, zero, or wildcard host means the server is listening on
+  # every network interface, not just this machine.
+  my $all_interfaces =
+       !defined $host
+    || $host eq ''
+    || $host eq '0'
+    || $host eq '0.0.0.0'
+    || $host eq '::';
+
+  my $ipv6     = defined $host && $host eq '::';
+  my $loopback = $ipv6 ? '::1' : '127.0.0.1';
+  my $display  = $all_interfaces ? $loopback : $host;
+  my $url_host = $display =~ /:/ ? "[$display]" : $display;
+
   print "Exporting '$self->{root}', available at:\n";
-  print "   $proto://$host:$port/\n";
+  print "   $proto://$url_host:$port/\n";
+
+  if ($all_interfaces) {
+    print "\n";
+    print "WARNING: this server is reachable on all network interfaces, so\n";
+    print "other machines on your network can access it. To limit access to\n";
+    print "this computer only, restart with: --host $loopback\n";
+  }
 
   return unless my $name = $self->{name};
 

--- a/t/server-ready.t
+++ b/t/server-ready.t
@@ -1,0 +1,59 @@
+use strict;
+use warnings;
+
+use Test::More;
+use App::HTTPThis;
+
+# Capture what _server_ready prints to the currently-selected filehandle.
+sub ready_output {
+  my (%args) = @_;
+  my $app = bless { root => '.' }, 'App::HTTPThis';
+
+  my $out = '';
+  open my $fh, '>', \$out or die "cannot open in-memory handle: $!";
+  my $old = select $fh;
+  $app->_server_ready( { proto => 'http', port => 7007, %args } );
+  select $old;
+  close $fh;
+
+  return $out;
+}
+
+subtest 'bound to all interfaces (no host)' => sub {
+  my $out = ready_output( host => 0 );
+  like $out, qr{http://127\.0\.0\.1:7007/}, 'shows a clickable localhost URL';
+  like $out, qr/all network interfaces/i,
+    'warns that it is reachable on all network interfaces';
+  like $out, qr/--host 127\.0\.0\.1/,
+    'explains how to restrict access to localhost';
+};
+
+subtest 'bound to all interfaces (0.0.0.0)' => sub {
+  my $out = ready_output( host => '0.0.0.0' );
+  like $out, qr{http://127\.0\.0\.1:7007/}, 'shows a clickable localhost URL';
+  like $out, qr/all network interfaces/i, 'warns about all interfaces';
+  like $out, qr/--host 127\.0\.0\.1/, 'explains how to restrict access';
+};
+
+subtest 'bound to localhost explicitly' => sub {
+  my $out = ready_output( host => '127.0.0.1' );
+  like $out, qr{http://127\.0\.0\.1:7007/}, 'shows the localhost URL';
+  unlike $out, qr/all network interfaces/i,
+    'no all-interfaces warning when bound to localhost';
+};
+
+subtest 'bound to a specific address' => sub {
+  my $out = ready_output( host => '192.168.0.5' );
+  like $out, qr{http://192\.168\.0\.5:7007/}, 'shows the requested host';
+  unlike $out, qr/all network interfaces/i,
+    'no all-interfaces warning for a specific address';
+};
+
+subtest 'bound to all interfaces (IPv6 ::)' => sub {
+  my $out = ready_output( host => '::' );
+  like $out, qr{http://\[::1\]:7007/}, 'shows the IPv6 loopback URL';
+  like $out, qr/all network interfaces/i, 'warns about all interfaces';
+  like $out, qr/--host ::1/, 'explains how to restrict access for IPv6';
+};
+
+done_testing;


### PR DESCRIPTION
## Summary

When `http_this` is started without `--host`, it binds to **all network interfaces** but the startup message claimed it was only available on localhost:

```
$ http_this --port 9099
Exporting '.', available at:
   http://127.0.0.1:9099/        # <-- but it actually listens on *:9099
```

This is the behaviour reported in **[RT #84641](https://rt.cpan.org/Public/Bug/Display.html?id=84641)** ("http_this should not listen on all interfaces and IP addresses by default").

## Cause

`HTTP::Server::PSGI` binds with `host => $args{host} || 0` (i.e. `INADDR_ANY`, all interfaces) when no host is given, then passes `host => 0` to the `server_ready` callback. In `_server_ready`, `0` is falsy, so `$args->{host} || '127.0.0.1'` made the message claim localhost.

## Change

This makes the message **honest** and **actionable**, without changing the default bind address:

- Detect the all-interfaces case (`undef`/empty/`0`/`0.0.0.0`/`::`).
- Still print a clickable loopback URL (`127.0.0.1`, or `[::1]` for IPv6).
- Add a warning that the server is reachable on all interfaces, and tell the user how to restrict it:

```
Exporting '.', available at:
   http://127.0.0.1:9099/

WARNING: this server is reachable on all network interfaces, so
other machines on your network can access it. To limit access to
this computer only, restart with: --host 127.0.0.1
```

An explicit `--host` (e.g. `--host 127.0.0.1`) prints just the URL, with no warning.

Also:
- Document the previously-undocumented `--host` option in `bin/http_this`.
- Add `t/server-ready.t` covering the message for each binding case (all-interfaces via `0`/`0.0.0.0`/`::`, explicit localhost, specific address).

## Note on RT #84641

The reporter asked for the **default** to become `127.0.0.1`. This PR deliberately does **not** change the default bind address, because that would be backward-incompatible for users who rely on reaching `http_this` from other machines on their LAN (a common use case). Instead it removes the misleading message and makes restricting to localhost easy and discoverable. Flagging so the ticket can be resolved as you see fit (it is referenced, not auto-closed).

## Testing

- `prove -Ilib t/` → all pass
- `podchecker bin/http_this` → OK
- Verified end-to-end by launching the binary with no host, `--host 127.0.0.1`, and `--host 0.0.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>